### PR TITLE
Fix zero total population bug in segregationcalc

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -349,13 +349,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // segregationcalc
-NumericVector segregationcalc(NumericMatrix distmat, NumericVector grouppop, NumericVector fullpop);
+arma::vec segregationcalc(const arma::umat distmat, const arma::vec grouppop, const arma::vec fullpop);
 RcppExport SEXP _redistmetrics_segregationcalc(SEXP distmatSEXP, SEXP grouppopSEXP, SEXP fullpopSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::traits::input_parameter< NumericMatrix >::type distmat(distmatSEXP);
-    Rcpp::traits::input_parameter< NumericVector >::type grouppop(grouppopSEXP);
-    Rcpp::traits::input_parameter< NumericVector >::type fullpop(fullpopSEXP);
+    Rcpp::traits::input_parameter< const arma::umat >::type distmat(distmatSEXP);
+    Rcpp::traits::input_parameter< const arma::vec >::type grouppop(grouppopSEXP);
+    Rcpp::traits::input_parameter< const arma::vec >::type fullpop(fullpopSEXP);
     rcpp_result_gen = Rcpp::wrap(segregationcalc(distmat, grouppop, fullpop));
     return rcpp_result_gen;
 END_RCPP

--- a/src/segregation.cpp
+++ b/src/segregation.cpp
@@ -59,12 +59,19 @@ NumericVector segregationcalc(NumericMatrix distmat,
 
       }
 
-      // Get district proportions
-      double p = (double)gpop / tpop;
+      if (tpop == 0.0) {
 
-      // Add to dissimilarity index
-      dissim += (double)d * tpop * std::abs(p - P);
+        dissim += 0;
 
+      } else {
+
+        // Get district proportions
+        double p = (double)gpop / tpop;
+
+        // Add to dissimilarity index
+        dissim += (double)d * tpop * std::abs(p - P);
+
+      }
     }
 
     // Add to vector

--- a/src/segregation.cpp
+++ b/src/segregation.cpp
@@ -5,83 +5,52 @@ using namespace Rcpp;
 NumericVector segregationcalc(NumericMatrix distmat,
                               NumericVector grouppop,
                               NumericVector fullpop) {
-
   // Vector to hold dissimilarity indices
   NumericVector diVec(distmat.ncol());
 
   // Population parameters
   int T = sum(fullpop);
-  double P = (double)sum(grouppop) / T;
+  double P = sum(grouppop) / T;
 
   // Calculate denominators
-  double d = (double)1 / (2 * T * P * (1 - P));
+  double d = 1.0 / (2.0 * T * P * (1 - P));
 
   // Get the number of unique plans
   NumericVector cd1 = distmat(_, 0);
   arma::vec cdVec1 = as<arma::vec> (cd1);
   arma::vec cdLabs = arma::unique(cdVec1);
 
-  // Range to look over for cd's
-  int start;
+  // Range to look over for CDs
   int end = max(cd1) + 1;
-  if(min(cd1) == 1){
-    start = 1;
-  }else{
-    start = 0;
-  }
+  int start = min(cd1) == 1 ? 1 : 0;
 
   // Loop over possible plans
-  for(int i = 0; i < distmat.ncol(); i++){
+  for (int i = 0; i < distmat.ncol(); i++) {
+    double dissim = 0.0;
+    arma::vec cds = as<arma::vec> (distmat(_, i));
 
-    // Create dissimilarity objects
-    double dissim = 0;
-
-    // Get a plan
-    NumericVector cdvec = distmat(_,i);
-    arma::vec cds = as<arma::vec> (cdvec);
-
-    // Loop over congressional districts
-    for(int j = start; j < end; j++){
-
-      // Initialize counts of groups
-      int tpop = 0;
-      int gpop = 0;
+    for (int j = start; j < end; j++) {
+      double tpop = 0.0;
+      double gpop = 0.0;
 
       // Which precincts in the plan are in this cd?
       arma::uvec findCds = find(cds == j);
 
       // Loop over precincts
-      for(int k = 0; k < findCds.size(); k++){
-
-        // Add population counts
+      for (int k = 0; k < findCds.size(); k++) {
         tpop += fullpop(findCds(k));
         gpop += grouppop(findCds(k));
-
       }
 
-      if (tpop == 0.0) {
-
-        dissim += 0;
-
-      } else {
-
-        // Get district proportions
-        double p = (double)gpop / tpop;
-
-        // Add to dissimilarity index
-        dissim += (double)d * tpop * std::abs(p - P);
-
+      if (tpop > 0.0) {
+        dissim += d * tpop * std::abs(gpop / tpop - P);
       }
     }
 
-    // Add to vector
     diVec(i) = dissim;
-
   }
 
-  // Return vector
   return diVec;
-
 }
 
 


### PR DESCRIPTION
Hi, great package! Big fan.

I think there's a bug in the internal `segregationcalc` function when there's 0 population in a district. Edge case for redistricting of course, but this comes up for one of my applications.

For example:

```
library(redistmetrics)

data(nh)
data(nh_m)

# hypothetical 3rd NH district with 0 population
nh$r_2020[nh$vap == 0] <- 3

seg_dissim(plans = nh$r_2020,
           shp = nh,
           group_pop = vap_hisp,
           total_pop = vap)

[1] NaN NaN NaN
```

Looks like a potential divide by 0 bug [here](https://github.com/alarm-redist/redistmetrics/blob/c62cef43bde256177c5f623e4f8c2a03b30b5a8d/src/segregation.cpp#L63), so I pushed a fix to `src/segregation.cpp` to add 0 to dissimilarity in those cases.

```
> seg_dissim(plans = nh$r_2020,
+            shp = nh,
+            group_pop = vap_hisp,
+            total_pop = vap)
[1] 0.01085658 0.01085658 0.01085658
```